### PR TITLE
Move running jobs to back of queue

### DIFF
--- a/stolos/queue_backend/qbcli_redis.py
+++ b/stolos/queue_backend/qbcli_redis.py
@@ -181,6 +181,7 @@ return 1
 local h_k = redis.call("ZRANGE", KEYS[1], 0, 0)[1]
 if nil == h_k then return {err="queue empty"} end
 if false == redis.call("SET", h_k, ARGV[1], "NX") then
+redis.call("ZINCRBY", KEYS[1], 5, h_k)
 return {err="already locked"} end
 if 1 ~= redis.call("EXPIREAT", h_k, ARGV[2]) then
 return {err="invalid expireat"} end


### PR DESCRIPTION
Currently when using the redis queue backend if a running job ends up at the front of the queue, it will
block further processing of the queue until the job completes. This change will move a running job at the front of the queue to a position at the back of the queue.